### PR TITLE
Add systemd dependency on clickhouse-server

### DIFF
--- a/packaging/graphite-ch-optimizer.service
+++ b/packaging/graphite-ch-optimizer.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Service to optimize stale GraphiteMergeTree tables
-After=network.target
+After=network.target clickhouse-server.service
+Wants=clickhouse-server.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
Without this dependency, graphite-ch-optimizer will try to start before the Clickhouse server is ready, leading to a failure to start.